### PR TITLE
Making configuration template immutable.

### DIFF
--- a/java/src/test/java/io/github/configur8/ConfigurationTemplateTest.java
+++ b/java/src/test/java/io/github/configur8/ConfigurationTemplateTest.java
@@ -1,0 +1,39 @@
+package io.github.configur8;
+
+import static io.github.configur8.ConfigurationTemplate.configurationTemplate;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ConfigurationTemplateTest {
+
+    public static final Property<String> FOO = Property.string("FOO");
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void requiringPropsIsImmutable() {
+        ConfigurationTemplate originalConfig = configurationTemplate().requiring(FOO);
+        ConfigurationTemplate updatedConfig = originalConfig.withProp(FOO, "bar");
+
+        assertThat(updatedConfig.reify().valueOf(FOO), is("bar"));
+
+        thrown.expectMessage(containsString("No value supplied for key 'FOO'"));
+        thrown.expect(Misconfiguration.class);
+        assertThat(originalConfig.reify().valueOf(FOO), is("foo"));
+    }
+
+    @Test
+    public void overridingPropsIsImmutable() {
+        ConfigurationTemplate originalConfig = configurationTemplate().withProp(FOO, "foo");
+        ConfigurationTemplate updatedConfig = originalConfig.withProp(FOO, "bar");
+
+        assertThat(originalConfig.reify().valueOf(FOO), is("foo"));
+        assertThat(updatedConfig.reify().valueOf(FOO), is("bar"));
+    }
+}

--- a/kotlin/src/test/kotlin/io/github/konfigur8/ConfigurationTemplateTest.kt
+++ b/kotlin/src/test/kotlin/io/github/konfigur8/ConfigurationTemplateTest.kt
@@ -1,0 +1,36 @@
+package io.github.konfigur8
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.Test
+import kotlin.test.fail
+
+class ConfigurationTemplateTest {
+
+    private val FOO = Property.string("FOO")
+
+    @Test
+    fun requiringPropsIsImmutable() {
+        try {
+            val originalConfig = ConfigurationTemplate().requiring(FOO)
+            val updatedConfig = ConfigurationTemplate().withProp(FOO, "foo")
+
+            assertThat(updatedConfig.reify().valueOf(FOO), equalTo("foo"))
+
+            originalConfig.reify()
+            fail("expected exception")
+        } catch(e: Misconfiguration) {
+            assertThat(e.message!!, equalTo("No value supplied for key 'FOO'"))
+        }
+    }
+
+    @Test
+    fun overridingPropsIsImmutable() {
+        val originalConfig = ConfigurationTemplate().withProp(FOO, "foo")
+        val updatedConfig = originalConfig.withProp(FOO, "bar")
+
+        assertThat(originalConfig.reify().valueOf(FOO), equalTo("foo"))
+        assertThat(updatedConfig.reify().valueOf(FOO), equalTo("bar"))
+    }
+
+}

--- a/scala/src/test/scala/io/github/configur8/ConfigurationTemplateTest.scala
+++ b/scala/src/test/scala/io/github/configur8/ConfigurationTemplateTest.scala
@@ -17,5 +17,23 @@ class ConfigurationTemplateTest extends FunSpec with Matchers {
     it("reification successful when all values supplied") {
       ConfigurationTemplate().requiring(intProperty).withProp(intProperty, 1).reify()
     }
+
+    it("requiring props is immutable") {
+      val original = ConfigurationTemplate().requiring(intProperty)
+      val updated = original.withProp(intProperty, 1)
+
+      updated.reify().valueOf(intProperty) shouldBe 1
+      intercept[Misconfiguration] {
+        original.reify()
+      }
+    }
+
+    it("with props is immutable") {
+      val original = ConfigurationTemplate().withProp(intProperty, 1)
+      val updated = original.withProp(intProperty, 2)
+
+      original.reify().valueOf(intProperty) shouldBe 1
+      updated.reify().valueOf(intProperty) shouldBe 2
+    }
   }
 }


### PR DESCRIPTION
Sorry I've only done this for the java version - am happy to have a crack at the kotlin & scala versions. The test isn't as clean as it maybe could be.