### PR TITLE
Allow configuration from map instead of env

### DIFF
--- a/kotlin/src/test/kotlin/io/github/konfigur8/ConfigurationTest.kt
+++ b/kotlin/src/test/kotlin/io/github/konfigur8/ConfigurationTest.kt
@@ -86,4 +86,29 @@ class ConfigurationTest {
         assertThat(list,equalTo(expected))
     }
 
+    @Test
+    fun takesPropFromMap() {
+        val config = ConfigurationTemplate().requiring(userProperty)
+        val configMap = mapOf(userProperty.name to "eliza")
+
+        assertThat(config.reifyFrom(configMap).valueOf(userProperty), equalTo("eliza"))
+    }
+
+    @Test
+    fun blowsUpWhenPropIsMissingInMap() {
+        try {
+            ConfigurationTemplate().requiring(userProperty).reifyFrom(emptyMap())
+            fail("expected exception")
+        } catch(e: Misconfiguration) {
+            assertThat(e.message!!, equalTo("No value supplied for key 'bob'"))
+        }
+    }
+
+    @Test
+    fun fallsBackToDefaultWhenPropIsMissingInMap() {
+        val config = ConfigurationTemplate().withProp(userProperty, "eliza")
+
+        assertThat(config.reifyFrom(emptyMap()).valueOf(userProperty), equalTo("eliza"))
+    }
+
 }


### PR DESCRIPTION
This allows for better testability of http4k serverless applications that use the AppLoader.
Adds a new method `reifyFrom` that reifies the configuration template from a map instead of getting the values from env/sysprops.

```kotlin
object AWSLambda : AppLoader {
    override fun invoke(env: Map<String, String>): HttpHandler {
        val config = ConfigurationTemplate().reifyFrom(env)
        
        return routes("/api" bind API(config))
    }
}